### PR TITLE
Fix map location on info page

### DIFF
--- a/info.html
+++ b/info.html
@@ -91,7 +91,7 @@
       </div>
 
       <div class="about-map">
-        <iframe src="https://www.google.com/maps?q=52.889841,-0.906779&t=k&z=15&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        <iframe src="https://www.google.com/maps/place/Skydive+Langar/@52.889841,-0.9093539,610m/data=!3m2!1e3!4b1!4m6!3m5!1s0x4879ce0d7392cfc5:0x1e15272b57ce5079!8m2!3d52.889841!4d-0.906779!16s%2Fg%2F1tfhfyvn!5m1!1e2?entry=ttu&g_ep=EgoyMDI1MDcyMC4wIKXMDSoASAFQAw%3D%3D&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- update info page map iframe to use precise coordinates

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install tidy -y` *(fails: Unable to locate package tidy)*

------
https://chatgpt.com/codex/tasks/task_e_6880fd9f4c94832c8b1fe3b0b0a2b9a9