### PR TITLE
Update FAQ layout and fonts

### DIFF
--- a/faqs.html
+++ b/faqs.html
@@ -6,7 +6,7 @@
     <title>Frequently asked questions – UoN Skydiving Club</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="soho-font">
 
     <!-- ================= HEADER ================= -->
     <header class="site-header">

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ html, body {
     height: 100%;
     display: flex;
     flex-direction: column;
-    font-family: 'Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    font-family: 'Soho Std', 'Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     color: #fff;
 }
 
@@ -159,6 +159,9 @@ body::before {
     font-family: 'Soho Std Light','Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     font-weight: 300;
 }
+.soho-font {
+    font-family: 'Soho Std', 'Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
 .about-section { display: flex; flex-wrap: wrap; gap: 2rem; align-items: flex-start; }
 .about-text b { font-weight: 800; }
 .about-map { flex: 0 1 350px; height: 350px; max-width: 450px; }
@@ -287,7 +290,7 @@ body::before {
 
 .faq-container {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 2rem;
 }
 

--- a/template.html
+++ b/template.html
@@ -6,7 +6,7 @@
     <title>Page Title</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="soho-font">
 
     <!-- ================= HEADER ================= -->
     <header class="site-header">


### PR DESCRIPTION
## Summary
- set body font to Soho Std
- add `.soho-font` utility class
- apply Soho Std font to FAQ and template pages
- restrict FAQ grid to two columns

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884b5166104832c8e93fc40b9c9d788