### PR TITLE
Refine header and info page layout

### DIFF
--- a/info.html
+++ b/info.html
@@ -82,16 +82,18 @@
     <hr class="divider" />
 
     <section class="about-section">
-      <div class="about-text">
-        <p>Welcome to the University of Nottingham Skydiving Club! We are a supportive and inclusive club that offers students at the University of Nottingham the chance to gain their <b>skydiving licence</b> and jump out of a plane <b>completely solo!</b></p>
+      <p class="about-text">Welcome to the University of Nottingham Skydiving Club! We are a supportive and inclusive club that offers students at the University of Nottingham the chance to gain their <b>skydiving licence</b> and jump out of a plane <b>completely solo!</b></p>
 
-        <p>Our home dropzone is <b>Skydive Langar</b>, an old RAF base located 30&nbsp;minutes from the university campus. Having completed 50,000 jumps in 2023, Skydive Langar is the <b>UK’s biggest dropzone</b> offering world‑class instructing and coaching for our members, and we’re proud to call it home.</p>
+      <div class="about-row">
+        <div class="about-column">
+          <p class="about-text">Our home dropzone is <b>Skydive Langar</b>, an old RAF base located 30&nbsp;minutes from the university campus. Having completed 50,000 jumps in 2023, Skydive Langar is the <b>UK’s biggest dropzone</b> offering world‑class instructing and coaching for our members, and we’re proud to call it home.</p>
 
-        <a href="https://www.skydivelangar.co.uk" target="_blank" rel="noopener noreferrer" class="btn-su btn-langar">SKYDIVE LANGAR</a>
-      </div>
+          <a href="https://www.skydivelangar.co.uk" target="_blank" rel="noopener noreferrer" class="btn-su btn-langar">SKYDIVE LANGAR</a>
+        </div>
 
-      <div class="about-map">
-        <iframe src="https://maps.google.com/maps?q=Skydive%20Langar&t=&z=13&ie=UTF8&iwloc=&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        <div class="about-map">
+          <iframe src="https://maps.google.com/maps?q=Skydive%20Langar&t=k&z=13&ie=UTF8&iwloc=&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        </div>
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -75,8 +75,8 @@ body::before {
 .btn-su {
     border: 3px solid #fff;
     padding: 1rem 3rem;
-    font-family: 'Soho Std Regular', 'Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-    font-weight: 300;
+    font-family: 'Soho Std Medium', 'Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    font-weight: 500;
     font-size: 0.8rem;
     color: #fff;
     text-decoration: none;
@@ -104,8 +104,8 @@ body::before {
 /* HERO TAGLINE ------------------------------------------------------ */
 .hero        { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: .5rem; padding: 1rem 1.5rem; }
 .tagline     { color: #fff; font-weight: 800; text-transform: uppercase; }
-.small-tag   { font-size: clamp(0.5rem, 4vw, 2rem); letter-spacing: .5px; }
-.big-tag     { font-size: clamp(1rem, 8vw, 4rem); white-space: nowrap; }
+.small-tag   { font-size: clamp(0.75rem, 5vw, 2.5rem); letter-spacing: .5px; }
+.big-tag     { font-size: clamp(1.5rem, 10vw, 5rem); white-space: nowrap; }
 .page-title  {
     text-transform: none;
     font-size: clamp(2.5rem, 6vw, 3rem);
@@ -133,14 +133,14 @@ body::before {
         gap: 1rem;
         justify-content: center;
     }
-    .small-tag { font-size: 1rem; }
-    .big-tag   { font-size: 2rem; }
+    .small-tag { font-size: 1.25rem; }
+    .big-tag   { font-size: 2.5rem; }
     .hero      { padding: 1rem; }
 }
 
 @media (min-width: 1024px) {
-    .small-tag { font-size: clamp(1rem, 2vw, 2rem); }
-    .big-tag   { font-size: clamp(2rem, 4vw, 4rem); }
+    .small-tag { font-size: clamp(1.25rem, 2.5vw, 2.5rem); }
+    .big-tag   { font-size: clamp(2.5rem, 5vw, 5rem); }
 }
 
 /* INFO PAGE LAYOUT ------------------------------------------------ */
@@ -151,25 +151,30 @@ body::before {
     gap: 3rem;
     padding: 1.5rem 1.5rem 3rem;
 }
+.info-main .page-title {
+    font-family: 'Futura', sans-serif;
+}
 .about-text {
-    flex: 1 1 300px;
-    line-height: 1.6;
+    line-height: 2;
     font-size: clamp(1.2rem, 1.8vw, 1.4rem);
     font-family: 'Soho Std Light','Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     font-weight: 300;
 }
-.soho-light {
-    font-family: 'Soho Std Light','Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-    font-weight: 300;
-}
+.about-section { display: flex; flex-direction: column; gap: 2rem; }
+.about-section > .about-text { width: 100%; }
+.about-row { display: flex; flex-wrap: wrap; gap: 2rem; align-items: flex-start; }
+.about-column { flex: 1 1 50%; }
+.about-text b { font-weight: 800; }
+.about-map { flex: 1 1 50%; width: 100%; aspect-ratio: 1 / 1; }
+.about-map iframe { width: 100%; height: 100%; border: 0; }
+.btn-langar { margin-top: 2rem; display: inline-block; }
 .soho-font {
     font-family: 'Soho Std', 'Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 }
-.about-section { display: flex; flex-wrap: wrap; gap: 2rem; align-items: flex-start; }
-.about-text b { font-weight: 800; }
-.about-map { flex: 0 1 350px; height: 350px; max-width: 450px; }
-.about-map iframe { width: 100%; height: 100%; border: 0; }
-.btn-langar { margin-top: 2rem; display: inline-block; }
+
+@media (max-width: 700px) {
+    .about-row { flex-direction: column; }
+}
 
 /* TILE GRID ------------------------------------------------------- */
 .tile-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 2rem; text-align: center; }
@@ -194,10 +199,12 @@ body::before {
     .main-nav,
     .social,
     .header-btn { display: none; }
+    .hamburger { display: inline-block; }
 }
 @media (min-width: 701px) {
     .mobile-overlay { display: none !important; }
     #nav-toggle { display: none; }
+    .hamburger { display: none; }
 }
 
 /* MOBILE MENU ----------------------------------------------------- */
@@ -260,7 +267,7 @@ body::before {
     height: 40px;
     z-index: 1001;
     cursor: pointer;
-    display: inline-block;
+    display: none;
 }
 .hamburger span {
     position: absolute;


### PR DESCRIPTION
## Summary
- Enlarge hero tagline and apply Soho Std Medium to the SU button
- Hide the hamburger menu on desktop
- Rework info page layout: Futura title, wider intro, side-by-side text and square satellite map with responsive stacking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936c78f3f8832c939b1f07bc38d579