### PR TITLE
Align backgrounds and adjust map layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,16 +23,16 @@ body::before {
     content: '';
     position: fixed;
     inset: 0;
-    background: #000 url('Images/Home Page Background.png') 50% 70%/cover no-repeat;
+    background: #000 url('Images/Home Page Background.png') center top/cover no-repeat;
     z-index: -1;
 }
 
 body.info-page::before {
-    background: #000 url('Images/Exit Background.webp') center/cover no-repeat;
+    background: #000 url('Images/Exit Background.webp') center top/cover no-repeat;
 }
 
 body.faqs-page::before {
-    background: #000 url('Images/Wing Tip Background.webp') center/cover no-repeat;
+    background: #000 url('Images/Wing Tip Background.webp') center top/cover no-repeat;
 }
 
 /* HEADER ------------------------------------------------------------ */
@@ -174,7 +174,7 @@ body.faqs-page::before {
 .about-row { display: flex; flex-wrap: nowrap; gap: 2rem; align-items: flex-start; }
 .about-column { flex: 1 1 50%; }
 .about-text b { font-weight: 800; }
-.about-map { flex: 1 1 50%; aspect-ratio: 1 / 1; }
+.about-map { flex: 1 1 50%; aspect-ratio: 4 / 3; }
 .about-map iframe { width: 100%; height: 100%; border: 0; }
 .btn-langar { margin-top: 2rem; display: inline-block; }
 .soho-font {


### PR DESCRIPTION
## Summary
- Align background images to the top of the viewport and keep them fixed for Info and FAQ pages.
- Set the Info page's Google Maps embed to a 4:3 landscape aspect ratio.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893e3cd8a78832c93e16d8a04fee894