### PR TITLE
Add background tint and adjust info page layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="home-page">
 
     <!-- ================= HEADER ================= -->
     <header class="site-header">

--- a/style.css
+++ b/style.css
@@ -32,7 +32,7 @@ body::before {
     right: 0;
     height: 100%;
     background: url('Images/Home Page Background.png') top center/100% auto no-repeat;
-    z-index: -1;
+    z-index: -2;
 }
 
 body.info-page::before {
@@ -41,6 +41,17 @@ body.info-page::before {
 
 body.faqs-page::before {
     background: url('Images/Wing Tip Background.webp') top center/100% auto no-repeat;
+}
+
+body:not(.home-page)::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.25);
+    z-index: -1;
 }
 
 /* HEADER ------------------------------------------------------------ */
@@ -165,7 +176,7 @@ body.faqs-page::before {
     display: flex;
     flex-direction: column;
     gap: 3rem;
-    padding: 1.5rem 1.5rem 3rem;
+    padding: 2rem 1.5rem 3rem;
 }
 .info-main .page-title {
     font-family: 'Futura', sans-serif;


### PR DESCRIPTION
## Summary
- Increase padding above "ABOUT US" on the info page for better separation from the header
- Introduce standardized 25% black overlay on all pages while exempting the home page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68952b027c20832ca71ed1ca42e6f924