### PR TITLE
Add how-to-join page with course info and CTA

### DIFF
--- a/how-to-join.html
+++ b/how-to-join.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How To Join – UoN Skydiving Club</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="soho-font">
+
+    <!-- ================= HEADER ================= -->
+    <header class="site-header">
+        <div class="header-top">
+            <div class="social">
+                <a href="https://www.instagram.com/uonskydiving/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M7.75 2h8.5A5.75 5.75 0 0122 7.75v8.5A5.75 5.75 0 0116.25 22h-8.5A5.75 5.75 0 012 16.25v-8.5A5.75 5.75 0 017.75 2zm0 1.5A4.25 4.25 0 003.5 7.75v8.5A4.25 4.25 0 007.75 20.5h8.5a4.25 4.25 0 004.25-4.25v-8.5A4.25 4.25 0 0016.25 3.5h-8.5zm8.25 1.75a.75.75 0 110 1.5.75.75 0 010-1.5zM12 7a5 5 0 110 10 5 5 0 010-10zm0 1.5a3.5 3.5 0 100 7 3.5 3.5 0 000-7z"/>
+                    </svg>
+                </a>
+                <a href="https://www.facebook.com/UoNSkydiving" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M9 8H7v4h2v12h5V12h3.642L17 8h-3V5.672C14 4.474 14.265 4 15.179 4H17V0h-2.928C10.807 0 9 1.66 9 4.615V8z"/>
+                    </svg>
+                </a>
+                <a href="https://www.youtube.com/@uonskydiving1700" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M23.498 6.186a2.997 2.997 0 00-2.11-2.12C19.645 3.444 12 3.444 12 3.444s-7.644 0-9.388.622a2.997 2.997 0 00-2.11 2.12C0 7.932 0 12 0 12s0 4.069.502 5.814a2.997 2.997 0 002.11 2.12c1.744.622 9.388.622 9.388.622s7.645 0 9.389-.622a2.997 2.997 0 002.11-2.12C24 16.068 24 12 24 12s0-4.068-.502-5.814-.502-5.814-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+                    </svg>
+                </a>
+            </div>
+
+            <a href="index.html">
+                <img src="Images/header_logo.png" alt="University of Nottingham Sport – Skydiving" class="logo">
+            </a>
+
+            <a href="https://su.nottingham.ac.uk/activities/view/skydive" target="_blank" rel="noopener noreferrer" class="btn-su">UoNSU</a>
+        </div>
+
+        <nav class="main-nav">
+            <ul>
+                <li><a href="info.html">INFO</a></li>
+                <li><a href="faqs.html">FAQS</a></li>
+                <li><a href="getting-your-licence.html">GETTING YOUR LICENCE</a></li>
+                <li><a href="dashboard.html">MEMBERS' DASHBOARD</a></li>
+                <li><a href="contact.html">CONTACT</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <!-- ================= MAIN CONTENT ================= -->
+    <main>
+        <section class="hero">
+            <h1 class="tagline big-tag">HOW TO JOIN</h1>
+        </section>
+
+        <hr class="divider" />
+
+        <section class="join-section">
+            <div class="join-text">
+                <p>So, how to join us and start skydiving?</p>
+                <p>To learn to skydive solo, you must complete either an <strong>AFF</strong> or a <strong>Static Line</strong> course (see buttons below for details). Both courses start with a day in the classroom, called a groundschool, where you’ll learn all the basics for your first solo jump. After that, it’s up to you—come back to continue jumping until you get your skydiving licence!</p>
+                <p>We advertise groundschool dates every semester on our Instagram page. To book a groundschool, drop us an email at <a href="mailto:skydive@uonsu.com">skydive@uonsu.com</a> telling us which of our advertised dates you’d like to attend. We’ll take some details and a deposit, and you’re sorted. If we haven’t got any groundschools advertised, email us anyway so we can get in touch when a spot becomes available.</p>
+                <p>All payments are made through the UoNSU site (link below). Deposits are non-refundable in most circumstances, as we have to pay for your slot if you don’t turn up. Your membership and deposit allow us to provide free transport for your groundschool, as well as free camping gear at the dropzone, which you’ll be able to use in future whenever you want to come back and stay for more than one day.</p>
+                <p>Once you’ve got your licence, you’ll have access to our very own UoN Skydiving rigs, worth thousands, for a very small yearly fee. Compared to hiring a rig for every jump, this is extremely good value.</p>
+                <p>We won’t lie to you—learning to skydive is expensive. But by doing your groundschool with us, not only do you get to join the biggest university skydiving community in the country, jumping at the most popular UK dropzone—you’ll be a skydiver for as cheap as possible! Once qualified, jumps are only £20.</p>
+                <p>Essentially, it’s worth the money. Email us to get started!</p>
+                <p><strong>Our email:</strong> <a href="mailto:skydive@uonsu.com">skydive@uonsu.com</a><br>
+                <strong>Alternatively, DM us on Instagram:</strong> <a href="https://www.instagram.com/uonskydiving/" target="_blank" rel="noopener noreferrer">@uonskydiving</a><br>
+                Please get in touch if you have any further questions!</p>
+            </div>
+            <div class="join-image">
+                <img src="Images/How To Join Thumbnail.webp" alt="Group of UoN skydivers in fancy dress by the aircraft at the dropzone.">
+            </div>
+        </section>
+
+        <hr class="divider" />
+
+        <section class="cta-section">
+            <div class="cta-buttons">
+                <a href="https://su.nottingham.ac.uk/activities/view/skydive" target="_blank" rel="noopener noreferrer" class="btn-su">UoNSU</a>
+                <a href="aff.html" class="btn-su">AFF COURSE INFO</a>
+                <a href="category-system.html" class="btn-su">STATIC LINE COURSE INFO</a>
+            </div>
+        </section>
+    </main>
+
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -463,3 +463,57 @@ body.contact-page::after {
 .contact-btn {
     margin-top: 1rem;
 }
+
+/* HOW TO JOIN PAGE STYLES -------------------------------------- */
+.join-section {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    align-items: flex-start;
+}
+
+.join-text {
+    flex: 1 1 300px;
+    max-width: 75ch;
+    line-height: 1.6;
+    font-family: 'Soho Std Light','Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    font-weight: 300;
+}
+
+.join-text p + p {
+    margin-top: 1rem;
+}
+
+.join-image {
+    flex: 1 1 350px;
+}
+
+.join-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    aspect-ratio: 3 / 2;
+    display: block;
+}
+
+.cta-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    justify-content: center;
+    margin: 2rem 1.5rem 3rem;
+}
+
+.cta-buttons a {
+    flex: 1 1 200px;
+    text-align: center;
+}
+
+@media (max-width: 600px) {
+    .join-image { margin-top: 2rem; }
+    .cta-buttons a { flex-basis: 100%; }
+}


### PR DESCRIPTION
## Summary
- Add how-to-join page with hero title only
- Include two-column section with joining info and image
- Provide CTA buttons for UoNSU, AFF, and Static Line course pages

## Testing
- `npx --yes htmlhint how-to-join.html` *(fails: 403 Forbidden - package access)*

------
https://chatgpt.com/codex/tasks/task_e_689e034c5e34832c8d91bc2579dde695