### PR TITLE
Add committee page with responsive grid

### DIFF
--- a/our-committee.html
+++ b/our-committee.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Our Committee – UoN Skydiving Club</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="committee-page">
+
+    <!-- ================= HEADER ================= -->
+    <header class="site-header">
+        <div class="header-top">
+            <div class="social">
+                <a href="https://www.instagram.com/uonskydiving/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M7.75 2h8.5A5.75 5.75 0 0122 7.75v8.5A5.75 5.75 0 0116.25 22h-8.5A5.75 5.75 0 012 16.25v-8.5A5.75 5.75 0 017.75 2zm0 1.5A4.25 4.25 0 003.5 7.75v8.5A4.25 4.25 0 007.75 20.5h8.5a4.25 4.25 0 004.25-4.25v-8.5A4.25 4.25 0 0016.25 3.5h-8.5zm8.25 1.75a.75.75 0 110 1.5.75.75 0 010-1.5zM12 7a5 5 0 110 10 5 5 0 010-10zm0 1.5a3.5 3.5 0 100 7 3.5 3.5 0 000-7z"/>
+                    </svg>
+                </a>
+                <a href="https://www.facebook.com/UoNSkydiving" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M9 8H7v4h2v12h5V12h3.642L17 8h-3V5.672C14 4.474 14.265 4 15.179 4H17V0h-2.928C10.807 0 9 1.66 9 4.615V8z"/>
+                    </svg>
+                </a>
+                <a href="https://www.youtube.com/@uonskydiving1700" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M23.498 6.186a2.997 2.997 0 00-2.11-2.12C19.645 3.444 12 3.444 12 3.444s-7.644 0-9.388.622a2.997 2.997 0 00-2.11 2.12C0 7.932 0 12 0 12s0 4.069.502 5.814a2.997 2.997 0 002.11 2.12c1.744.622 9.388.622 9.388.622s7.645 0 9.389-.622a2.997 2.997 0 002.11-2.12C24 16.068 24 12 24 12s0-4.068-.502-5.814-.502-5.814-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+                    </svg>
+                </a>
+            </div>
+
+            <a href="index.html">
+                <img src="Images/header_logo.png" alt="University of Nottingham Sport – Skydiving" class="logo">
+            </a>
+
+            <a href="https://su.nottingham.ac.uk/activities/view/skydive" target="_blank" rel="noopener noreferrer" class="btn-su">UoNSU</a>
+        </div>
+
+        <nav class="main-nav">
+            <ul>
+                <li><a href="info.html">INFO</a></li>
+                <li><a href="faqs.html">FAQS</a></li>
+                <li><a href="getting-your-licence.html">GETTING YOUR LICENCE</a></li>
+                <li><a href="dashboard.html">MEMBERS' DASHBOARD</a></li>
+                <li><a href="contact.html">CONTACT</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <!-- ================= MAIN CONTENT ================= -->
+    <main>
+        <section class="hero committee-hero">
+            <h1 class="tagline big-tag">Our COMMITTEE</h1>
+        </section>
+
+        <section class="committee-section">
+            <div class="committee-grid">
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/president.jpg" alt="Photo of President">
+                    <figcaption>
+                        <span class="committee-name">NAME</span>
+                        <span class="committee-role">PRESIDENT</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/vice-president.jpg" alt="Photo of Vice President">
+                    <figcaption>
+                        <span class="committee-name">NAME</span>
+                        <span class="committee-role">VICE PRESIDENT</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/treasurer.jpg" alt="Photo of Treasurer">
+                    <figcaption>
+                        <span class="committee-name">NAME</span>
+                        <span class="committee-role">TREASURER</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/general-secretary.jpg" alt="Photo of General Secretary">
+                    <figcaption>
+                        <span class="committee-name">NAME</span>
+                        <span class="committee-role">GENERAL SECRETARY</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/kit-secretary.jpg" alt="Photo of Kit Secretary">
+                    <figcaption>
+                        <span class="committee-name">NAME</span>
+                        <span class="committee-role">KIT SECRETARY</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/social-welfare-1.jpg" alt="Photo of Social and Welfare Secretary">
+                    <figcaption>
+                        <span class="committee-name">NAME</span>
+                        <span class="committee-role">SOCIAL AND WELFARE SECRETARY</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/social-welfare-2.jpg" alt="Photo of Social and Welfare Secretary">
+                    <figcaption>
+                        <span class="committee-name">NAME</span>
+                        <span class="committee-role">SOCIAL AND WELFARE SECRETARY</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/publicity.jpg" alt="Photo of Publicity Secretary">
+                    <figcaption>
+                        <span class="committee-name">NAME</span>
+                        <span class="committee-role">PUBLICITY SECRETARY</span>
+                    </figcaption>
+                </figure>
+            </div>
+        </section>
+    </main>
+
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -463,3 +463,105 @@ body.contact-page::after {
 .contact-btn {
     margin-top: 1rem;
 }
+
+/* COMMITTEE PAGE STYLES ----------------------------------------- */
+body.committee-page::before {
+    background: none;
+}
+
+.committee-hero {
+    position: relative;
+    background: url('Images/committee/hero.jpg') center/cover no-repeat;
+}
+
+.committee-hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to bottom, rgba(0,0,0,0.4), rgba(0,0,0,0.7));
+}
+
+.committee-hero h1 {
+    position: relative;
+}
+
+.committee-section {
+    padding: 4rem 1.5rem 3rem;
+    background-color: #000;
+}
+
+.committee-grid {
+    display: grid;
+    gap: 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 600px) {
+    .committee-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 1024px) {
+    .committee-grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+.committee-card {
+    position: relative;
+    overflow: hidden;
+    aspect-ratio: 4 / 5;
+    outline: none;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.committee-card img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: transform 0.3s ease;
+}
+
+.committee-card:hover img,
+.committee-card:focus img {
+    transform: scale(1.02);
+}
+
+.committee-card:hover,
+.committee-card:focus {
+    box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+}
+
+.committee-card:focus {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+}
+
+.committee-card figcaption {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 1rem;
+    background: linear-gradient(to top, rgba(0,0,0,0.6), rgba(0,0,0,0));
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.committee-name {
+    font-weight: 800;
+    text-transform: uppercase;
+    color: #fff;
+}
+
+.committee-role {
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.8);
+}


### PR DESCRIPTION
## Summary
- Add `our-committee.html` with hero header, committee grid placeholders, and accessibility-focused markup.
- Style committee page with dark hero image, responsive 4x2 grid, hover/focus effects, and legible text overlays.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e06309218832cb3f28fbebe5c0788