### PR TITLE
Add past committee page with committee grid and qualifiers

### DIFF
--- a/past-committee.html
+++ b/past-committee.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Past Committee – UoN Skydiving</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="soho-font committee-page">
+
+    <!-- ================= HEADER ================= -->
+    <header class="site-header">
+        <div class="header-top">
+            <div class="social">
+                <a href="https://www.instagram.com/uonskydiving/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M7.75 2h8.5A5.75 5.75 0 0122 7.75v8.5A5.75 5.75 0 0116.25 22h-8.5A5.75 5.75 0 012 16.25v-8.5A5.75 5.75 0 017.75 2zm0 1.5A4.25 4.25 0 003.5 7.75v8.5A4.25 4.25 0 007.75 20.5h8.5a4.25 4.25 0 004.25-4.25v-8.5A4.25 4.25 0 0016.25 3.5h-8.5zm8.25 1.75a.75.75 0 110 1.5.75.75 0 010-1.5zM12 7a5 5 0 110 10 5 5 0 010-10zm0 1.5a3.5 3.5 0 100 7 3.5 3.5 0 000-7z"/>
+                    </svg>
+                </a>
+                <a href="https://www.facebook.com/UoNSkydiving" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M9 8H7v4h2v12h5V12h3.642L17 8h-3V5.672C14 4.474 14.265 4 15.179 4H17V0h-2.928C10.807 0 9 1.66 9 4.615V8z"/>
+                    </svg>
+                </a>
+                <a href="https://www.youtube.com/@uonskydiving1700" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M23.498 6.186a2.997 2.997 0 00-2.11-2.12C19.645 3.444 12 3.444 12 3.444s-7.644 0-9.388.622a2.997 2.997 0 00-2.11 2.12C0 7.932 0 12 0 12s0 4.069.502 5.814a2.997 2.997 0 002.11 2.12c1.744.622 9.388.622 9.388.622s7.645 0 9.389-.622a2.997 2.997 0 002.11-2.12C24 16.068 24 12 24 12s0-4.068-.502-5.814-.502-5.814-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+                    </svg>
+                </a>
+            </div>
+
+            <a href="index.html">
+                <img src="Images/header_logo.png" alt="University of Nottingham Sport – Skydiving" class="logo">
+            </a>
+
+            <a href="https://su.nottingham.ac.uk/activities/view/skydive" target="_blank" rel="noopener noreferrer" class="btn-su">UoNSU</a>
+        </div>
+
+        <nav class="main-nav">
+            <ul>
+                <li><a href="info.html">INFO</a></li>
+                <li><a href="faqs.html">FAQS</a></li>
+                <li><a href="getting-your-licence.html">GETTING YOUR LICENCE</a></li>
+                <li><a href="dashboard.html">MEMBERS' DASHBOARD</a></li>
+                <li><a href="contact.html">CONTACT</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <!-- ================= MAIN CONTENT ================= -->
+    <main>
+        <section class="hero committee-hero">
+            <h1 class="tagline big-tag">OUR COMMITTEE</h1>
+        </section>
+
+        <hr class="divider" />
+
+        <section class="committee">
+            <div class="committee-grid">
+                <div class="committee-card">
+                    <div class="committee-photo" role="img" aria-label="Headshot of Jasper Pyer"></div>
+                    <h3 class="committee-name">Jasper Pyer</h3>
+                    <p class="committee-role">PRESIDENT</p>
+                </div>
+                <div class="committee-card">
+                    <div class="committee-photo" role="img" aria-label="Headshot of Fern Devonport"></div>
+                    <h3 class="committee-name">Fern Devonport</h3>
+                    <p class="committee-role">VICE PRESIDENT</p>
+                </div>
+                <div class="committee-card">
+                    <div class="committee-photo" role="img" aria-label="Headshot of Morgan Lee"></div>
+                    <h3 class="committee-name">Morgan Lee</h3>
+                    <p class="committee-role">TREASURER</p>
+                </div>
+                <div class="committee-card">
+                    <div class="committee-photo" role="img" aria-label="Headshot of Maddie Trask"></div>
+                    <h3 class="committee-name">Maddie Trask</h3>
+                    <p class="committee-role">GENERAL SECRETARY</p>
+                </div>
+                <div class="committee-card">
+                    <div class="committee-photo" role="img" aria-label="Headshot of Nicholas Geere"></div>
+                    <h3 class="committee-name">Nicholas Geere</h3>
+                    <p class="committee-role">KIT SECRETARY</p>
+                </div>
+                <div class="committee-card">
+                    <div class="committee-photo" role="img" aria-label="Headshot of Amity Duncan"></div>
+                    <h3 class="committee-name">Amity Duncan</h3>
+                    <p class="committee-role">SOCIAL SECRETARY</p>
+                </div>
+                <div class="committee-card">
+                    <div class="committee-photo" role="img" aria-label="Headshot of Tom Prosser"></div>
+                    <h3 class="committee-name">Tom Prosser</h3>
+                    <p class="committee-role">SOCIAL SECRETARY</p>
+                </div>
+                <div class="committee-card">
+                    <div class="committee-photo" role="img" aria-label="Headshot of Sebastian Taylor"></div>
+                    <h3 class="committee-name">Sebastian Taylor</h3>
+                    <p class="committee-role">PUBLICITY SECRETARY</p>
+                </div>
+            </div>
+        </section>
+
+        <hr class="divider" />
+
+        <section class="qualifiers">
+            <h2 class="qualifiers-heading">QUALIFIERS</h2>
+            <h3 class="qualifiers-subheading">2023/24</h3>
+            <ul class="qualifiers-list">
+                <li>Seif Alshunnar</li>
+                <li>Abi Virgo</li>
+                <li>Kirsty Tidmus</li>
+            </ul>
+        </section>
+    </main>
+
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -463,3 +463,88 @@ body.contact-page::after {
 .contact-btn {
     margin-top: 1rem;
 }
+
+/* COMMITTEE PAGE STYLES -------------------------------------------- */
+body.committee-page::before {
+    background: none;
+}
+
+.committee-hero {
+    background: url('Images/Langar Evening Background.webp') center/cover no-repeat;
+}
+
+.committee {
+    padding: 3rem 1.5rem 0;
+}
+
+.committee-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 3rem 2rem;
+    justify-items: start;
+}
+
+.committee-photo {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    background-color: #444;
+    background-size: cover;
+    background-position: center;
+    transition: transform 0.2s ease;
+    display: block;
+}
+
+.committee-card:hover .committee-photo {
+    transform: translateY(-4px);
+}
+
+.committee-name {
+    margin-top: 0.75rem;
+    font-weight: 800;
+    font-size: 1.25rem;
+}
+
+.committee-role {
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #ccc;
+}
+
+.qualifiers {
+    padding: 3rem 1.5rem;
+}
+
+.qualifiers-heading {
+    font-size: 1.5rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.qualifiers-subheading {
+    margin-top: 0.25rem;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    font-family: 'Soho Std Light','Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    font-weight: 300;
+}
+
+.qualifiers-list {
+    list-style: none;
+    padding: 0;
+    margin-top: 1rem;
+    line-height: 1.6;
+}
+
+@media (max-width: 800px) {
+    .committee-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 600px) {
+    .committee-grid {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `past-committee.html` from template and populate with committee members grid and qualifiers section.
- Style committee page with responsive grid, hero background, and CSS-based placeholders for committee member images.
- Remove placeholder image asset.

## Testing
- `npx --yes htmlhint past-committee.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_689e08ae4de4832c83e27425a686a4a9