### PR TITLE
Add past committee page with grid and qualifiers

### DIFF
--- a/Images/committee/placeholder.svg
+++ b/Images/committee/placeholder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="360" viewBox="0 0 360 360" preserveAspectRatio="xMidYMid slice">
+  <rect width="360" height="360" fill="#666"/>
+</svg>

--- a/past-committee.html
+++ b/past-committee.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Past Committee – UoN Skydiving Club</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="committee-page">
+
+    <!-- ================= HEADER ================= -->
+    <header class="site-header">
+        <div class="header-top">
+            <div class="social">
+                <a href="https://www.instagram.com/uonskydiving/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M7.75 2h8.5A5.75 5.75 0 0122 7.75v8.5A5.75 5.75 0 0116.25 22h-8.5A5.75 5.75 0 012 16.25v-8.5A5.75 5.75 0 017.75 2zm0 1.5A4.25 4.25 0 003.5 7.75v8.5A4.25 4.25 0 007.75 20.5h8.5a4.25 4.25 0 004.25-4.25v-8.5A4.25 4.25 0 0016.25 3.5h-8.5zm8.25 1.75a.75.75 0 110 1.5.75.75 0 010-1.5zM12 7a5 5 0 110 10 5 5 0 010-10zm0 1.5a3.5 3.5 0 100 7 3.5 3.5 0 000-7z"/>
+                    </svg>
+                </a>
+                <a href="https://www.facebook.com/UoNSkydiving" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M9 8H7v4h2v12h5V12h3.642L17 8h-3V5.672C14 4.474 14.265 4 15.179 4H17V0h-2.928C10.807 0 9 1.66 9 4.615V8z"/>
+                    </svg>
+                </a>
+                <a href="https://www.youtube.com/@uonskydiving1700" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M23.498 6.186a2.997 2.997 0 00-2.11-2.12C19.645 3.444 12 3.444 12 3.444s-7.644 0-9.388.622a2.997 2.997 0 00-2.11 2.12C0 7.932 0 12 0 12s0 4.069.502 5.814a2.997 2.997 0 002.11 2.12c1.744.622 9.388.622 9.388.622s7.645 0 9.389-.622a2.997 2.997 0 002.11-2.12C24 16.068 24 12 24 12s0-4.068-.502-5.814-.502-5.814-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+                    </svg>
+                </a>
+            </div>
+
+            <a href="index.html">
+                <img src="Images/header_logo.png" alt="University of Nottingham Sport – Skydiving" class="logo">
+            </a>
+
+            <a href="https://su.nottingham.ac.uk/activities/view/skydive" target="_blank" rel="noopener noreferrer" class="btn-su">UoNSU</a>
+        </div>
+
+        <nav class="main-nav">
+            <ul>
+                <li><a href="info.html">INFO</a></li>
+                <li><a href="faqs.html">FAQS</a></li>
+                <li><a href="getting-your-licence.html">GETTING YOUR LICENCE</a></li>
+                <li><a href="dashboard.html">MEMBERS' DASHBOARD</a></li>
+                <li><a href="contact.html">CONTACT</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <!-- ================= MAIN CONTENT ================= -->
+    <main>
+        <section class="hero past-committee-hero">
+            <h1 class="tagline big-tag">OUR COMMITTEE</h1>
+        </section>
+
+        <hr class="divider" />
+
+        <section class="committee-section">
+            <div class="committee-grid">
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/jasper-pyer.jpg" alt="Headshot of Jasper Pyer" onerror="this.onerror=null;this.src='Images/committee/placeholder.svg';">
+                    <figcaption>
+                        <span class="committee-name">Jasper Pyer</span>
+                        <span class="committee-role">PRESIDENT</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/fern-devonport.jpg" alt="Headshot of Fern Devonport" onerror="this.onerror=null;this.src='Images/committee/placeholder.svg';">
+                    <figcaption>
+                        <span class="committee-name">Fern Devonport</span>
+                        <span class="committee-role">VICE PRESIDENT</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/morgan-lee.jpg" alt="Headshot of Morgan Lee" onerror="this.onerror=null;this.src='Images/committee/placeholder.svg';">
+                    <figcaption>
+                        <span class="committee-name">Morgan Lee</span>
+                        <span class="committee-role">TREASURER</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/maddie-trask.jpg" alt="Headshot of Maddie Trask" onerror="this.onerror=null;this.src='Images/committee/placeholder.svg';">
+                    <figcaption>
+                        <span class="committee-name">Maddie Trask</span>
+                        <span class="committee-role">GENERAL SECRETARY</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/nicholas-geere.jpg" alt="Headshot of Nicholas Geere" onerror="this.onerror=null;this.src='Images/committee/placeholder.svg';">
+                    <figcaption>
+                        <span class="committee-name">Nicholas Geere</span>
+                        <span class="committee-role">KIT SECRETARY</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/amity-duncan.jpg" alt="Headshot of Amity Duncan" onerror="this.onerror=null;this.src='Images/committee/placeholder.svg';">
+                    <figcaption>
+                        <span class="committee-name">Amity Duncan</span>
+                        <span class="committee-role">SOCIAL SECRETARY</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/tom-prosser.jpg" alt="Headshot of Tom Prosser" onerror="this.onerror=null;this.src='Images/committee/placeholder.svg';">
+                    <figcaption>
+                        <span class="committee-name">Tom Prosser</span>
+                        <span class="committee-role">SOCIAL SECRETARY</span>
+                    </figcaption>
+                </figure>
+
+                <figure class="committee-card" tabindex="0">
+                    <img src="Images/committee/sebastian-taylor.jpg" alt="Headshot of Sebastian Taylor" onerror="this.onerror=null;this.src='Images/committee/placeholder.svg';">
+                    <figcaption>
+                        <span class="committee-name">Sebastian Taylor</span>
+                        <span class="committee-role">PUBLICITY SECRETARY</span>
+                    </figcaption>
+                </figure>
+            </div>
+        </section>
+
+        <hr class="divider" />
+
+        <section class="qualifiers-section">
+            <h2>QUALIFIERS</h2>
+            <h3>2023/24</h3>
+            <ul class="qualifiers-list">
+                <li>Seif Alshunnar</li>
+                <li>Abi Virgo</li>
+                <li>Kirsty Tidmus</li>
+            </ul>
+        </section>
+    </main>
+
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -732,6 +732,22 @@ body.committee-page::before {
     position: relative;
 }
 
+.past-committee-hero {
+    position: relative;
+    background: url('Images/Langar Evening Background.webp') center/cover no-repeat;
+}
+
+.past-committee-hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to bottom, rgba(0,0,0,0.4), rgba(0,0,0,0.7));
+}
+
+.past-committee-hero h1 {
+    position: relative;
+}
+
 .committee-section {
     padding: 4rem 1.5rem 3rem;
     background-color: #000;
@@ -776,6 +792,23 @@ body.committee-page::before {
 .committee-card:hover img,
 .committee-card:focus img {
     transform: scale(1.02);
+}
+
+.qualifiers-section {
+    padding: 4rem 1.5rem;
+    background-color: #000;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.qualifiers-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.qualifiers-list li + li {
+    margin-top: 0.5rem;
 }
 
 .committee-card:hover,


### PR DESCRIPTION
## Summary
- add past committee page with hero image and committee grid
- include qualifiers section and placeholder image fallback
- style past committee hero and qualifiers block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e0d1045c4832ca5916a9795bd1fc7