### PR TITLE
Update FAQ page links and layout

### DIFF
--- a/faqs.html
+++ b/faqs.html
@@ -54,7 +54,7 @@
           <div class="faq-container">
             <div class="faq-item">
               <h2>Can I skydive?</h2>
-              <p>Absolutely! We offer two training courses, AFF and the Category System, which will train you to skydive completely on your own! Finishing a skydiving course gives you your British Skydiving <strong>A Licence</strong>.</p>
+              <p>Absolutely! We offer two training courses, <a href="AFF.html">AFF</a> and the <a href="category-system.html">Category System</a>, which will train you to skydive completely on your own! Finishing a skydiving course gives you your British Skydiving <strong>A Licence</strong>.</p>
             </div>
 
             <div class="faq-item">
@@ -64,7 +64,7 @@
 
             <div class="faq-item">
               <h2>How much does it cost?</h2>
-              <p>Go to <a href="pricing.html">pricing</a> for the most up-to-date prices.<br>While initial training can be a bit expensive, you can jump for just £20 once you get your licence!</p>
+              <p>Go to <a href="prices.html">pricing</a> for the most up-to-date prices.<br>While initial training can be a bit expensive, you can jump for just £20 once you get your licence!</p>
             </div>
 
             <div class="faq-item">
@@ -74,7 +74,7 @@
 
             <div class="faq-item">
               <h2>Is skydiving safe?</h2>
-              <p>Yes! Skydiving is a highly regulated sport with abundant safety measures. If you do experience a parachute malfunction there are safety measures such as automatic activation devices (AADs) on parachute rigs which will automatically release a reserve parachute if you are unable to deploy your main parachute.<br><a href="https://www.skydivelangar.co.uk/is-skydiving-safe/" target="_blank" rel="noopener noreferrer">This article provides further information on safety in skydiving.</a></p>
+              <p>Yes! Skydiving is a highly regulated sport with abundant safety measures. If you do experience a parachute malfunction there are safety measures such as automatic activation devices (AADs) on parachute rigs which will automatically release a reserve parachute if you are unable to deploy your main parachute.<br><a href="https://www.skydivelangar.co.uk/is-skydiving-safe/" target="_blank" rel="noopener noreferrer">https://www.skydivelangar.co.uk/is-skydiving-safe/</a></p>
             </div>
 
             <div class="faq-item">
@@ -99,7 +99,7 @@
 
             <div class="faq-item">
               <h2>How can I check the weather?</h2>
-              <p>Weather plays a crucial role in skydiving, as we rely on clear skies and low winds. The wind limit is 18mph for students.<br>You can check the weather forecast on any reliable website, such as <a href="https://www.metcheck.com" target="_blank" rel="noopener noreferrer">Metcheck</a>.</p>
+              <p>Weather plays a crucial role in skydiving, as we rely on clear skies and low winds. The wind limit is 18mph for students.<br>You can check the weather forecast on any reliable website, such as <a href="https://www.metcheck.com/HOBBIES/skydiving_forecast.asp?location=52%2E8898%2F%2D0%2E9067&locationID=&lat=52.889800&lon=-0.906700" target="_blank" rel="noopener noreferrer">Metcheck</a>.</p>
             </div>
 
             <div class="faq-item">
@@ -109,12 +109,12 @@
 
             <div class="faq-item">
               <h2>How do I pay for everything?</h2>
-              <p>For all purchases such as your membership, groundschool deposit, jump tickets and kit hire for experienced members, visit the UoNSU website and purchase the correct items through the products and merchandise page.</p>
+              <p>For all purchases such as your membership, groundschool deposit, jump tickets and kit hire for experienced members, visit the <a href="https://su.nottingham.ac.uk/activities/view/skydive" target="_blank" rel="noopener noreferrer">UoNSU</a> website and purchase the correct items through the products and merchandise page.</p>
             </div>
 
             <div class="faq-item">
               <h2>How can I arrange transportation to Langar?</h2>
-              <p>You can join the Transportation - UoN Sport Skydiving Facebook group, where you can ask for a lift, or arrange a taxi with other members if there are no available drivers. Lifts to Langar are £2.50 each way, and you can pay by buying transport tickets through the UoNSU website.<br>Alternatively, you can take the train from Nottingham Station to Bingham and arrange a lift from there. Please remember to be respectful when arranging transport, and to buy transport tickets BEFORE you go!</p>
+              <p>You can join the <a href="https://www.facebook.com/groups/skysoc.transportation/" target="_blank" rel="noopener noreferrer">Transportation - UoN Sport Skydiving</a> Facebook group, where you can ask for a lift, or arrange a taxi with other members if there are no available drivers. Lifts to Langar are £2.50 each way, and you can pay by buying <a href="https://su.nottingham.ac.uk/activities/view/skydive" target="_blank" rel="noopener noreferrer">transport tickets</a> through the <a href="https://su.nottingham.ac.uk/activities/view/skydive" target="_blank" rel="noopener noreferrer">UoNSU website</a>.<br>Alternatively, you can take the train from Nottingham Station to Bingham and arrange a lift from there. Please remember to be respectful when arranging transport, and to buy transport tickets BEFORE you go!</p>
             </div>
 
             <div class="faq-item">
@@ -124,7 +124,7 @@
 
             <div class="faq-item">
               <h2>I have more questions!</h2>
-              <p>If you still have questions feel free to send us a message and we’ll be happy to help! Either send us an email or DM us on Instagram or Facebook.<br><a href="mailto:skydive@uonsu.com">skydive@uonsu.com</a><br>@uonskydiving</p>
+              <p>If you still have questions feel free to send us a message and we’ll be happy to help! Either send us an email or DM us on Instagram or Facebook.<br><br><a href="mailto:skydive@uonsu.com">skydive@uonsu.com</a><br><br>@uonskydiving</p>
             </div>
           </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -40,7 +40,10 @@ body.info-page::before {
 }
 
 body.faqs-page::before {
-    background: url('Images/Wing Tip Background.webp') top center/100% auto no-repeat;
+    background-image: url('Images/Wing Tip Background.webp');
+    background-position: center 0;
+    background-size: cover;
+    background-repeat: no-repeat;
 }
 
 body:not(.home-page)::after {
@@ -429,6 +432,10 @@ body:not(.home-page)::after {
 .faq-item a {
     color: #fff;
     text-decoration: underline;
+}
+
+.faq-item a:visited {
+    color: #fff;
 }
 
 /* LICENCE PAGE STYLES -------------------------------------------- */


### PR DESCRIPTION
## Summary
- Reposition FAQ background image to start at page top and keep link colors consistent
- Link training courses, pricing, safety, weather, payments, transport and contacts to their destinations
- Add spacing in final FAQ entry for clearer contact details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e14c9d5e8832c9334c15014653ac8