### PR TITLE
Standardize layout utilities across pages

### DIFF
--- a/AFF.html
+++ b/AFF.html
@@ -48,7 +48,7 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero aff-hero">
             <div class="hero-inner">
                 <div class="hero-text">
@@ -68,14 +68,14 @@
 
         <hr class="divider" />
 
-        <section class="content-section">
+        <section class="section container">
             <p>AFF stands for Accelerated Freefall, and it is the most popular way of learning to skydive across the world, as it is the faster and a more sure-fire way option to become qualified. You’ll also be able to experience the rush of freefall from the very beginning as you’ll be jumping out at maximum altitude, 14,000ft, with two instructors holding onto you! On the way down under parachute, you’ll have a radio in your helmet to give a helping hand for the first few jumps.</p>
             <p>Once you’ve completed a day’s groundschool, it is up to you whenever you come back to complete your levels and then your consols, until you have a skydiving licence!</p>
         </section>
 
         <hr class="divider" />
 
-        <section class="content-section course-section">
+        <section class="course-section section container">
             <h2>THE COURSE</h2>
             <div class="course-content">
                 <div class="course-left">

--- a/category-system.html
+++ b/category-system.html
@@ -48,12 +48,12 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero">
             <h1 class="tagline big-tag">Category System</h1>
         </section>
 
-        <section class="intro-summary">
+        <section class="intro-summary section container">
             <ul class="intro-list">
                 <li>The Category System course is great for those who aren’t initially sure about paying for AFF.</li>
                 <li>You will jump paratrooper-style from 3,500 ft, attached to a static line which deploys your parachute when you exit the aircraft.</li>
@@ -65,7 +65,7 @@
 
         <hr class="divider" />
 
-        <section class="content-section course-overview">
+        <section class="course-overview section container">
             <h2>Course overview</h2>
             <p>The Category System is the cheaper course available to skydivers on a budget who might just want to experience jumping out of a plane a few times, before deciding whether to go ahead with getting their licence. Please note a static-line jump is not a typical skydive – you won’t progress onto freefall until you’ve completed multiple jumps on the line and perfected your body position. You can find details on the later levels below.</p>
             <p>Your first jumps will be on a static line. When you jump out of the plane, after a few seconds the line becomes taut and will pull your parachute out of your rig – then it’s up to you to put your training into practice by flying and landing your canopy. On your first few jumps, you will have a helping hand to get you down safely via a radio in your helmet.</p>
@@ -73,7 +73,7 @@
 
         <hr class="divider" />
 
-        <section class="content-section course-section">
+        <section class="course-section section container">
             <div class="course-container">
                 <div class="course-left">
                     <h2 class="section-title course-title">THE COURSE</h2>

--- a/contact-us.html
+++ b/contact-us.html
@@ -49,7 +49,7 @@
 
     <!-- ================= MAIN CONTENT ================= -->
     <main>
-        <section class="hero contact-hero">
+        <section class="hero centered">
             <h1 class="tagline big-tag">Contact us!</h1>
             <div class="contact-details">
                 <p>Email : <a href="mailto:skydive@uonsu.com">skydive@uonsu.com</a></p>

--- a/faqs.html
+++ b/faqs.html
@@ -48,8 +48,8 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
-        <section class="faq-section">
+    <main class="content">
+        <section class="faq-section section container">
           <h1 class="tagline page-title">Frequently asked questions</h1>
           <div class="faq-container">
             <div class="faq-item">

--- a/getting-your-licence.html
+++ b/getting-your-licence.html
@@ -48,7 +48,7 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero">
             <h1 class="tagline big-tag">GETTING YOUR LICENCE</h1>
             <p>When you join UoN Skydiving, you’ll have the exciting opportunity to pursue your skydiving licence through two different courses: Accelerated Freefall (AFF) or the Category System.
@@ -57,21 +57,21 @@ Both courses lead to earning your A Licence, but have different prices and teach
 
         <hr class="divider" />
 
-        <section class="content-section">
+        <section class="section container">
             <h2>Accelerated Freefall (AFF)</h2>
             <p>AFF is the most common and popular option of learning to skydive worldwide. You will progress faster and enjoy freefall from your first jump, with the help of instructors jumping with you to coach you and give feedback. You have the option to pay as you go, or to pay upfront after your first jump for a discount. You will have a skydiving licence in 18 solo jumps, at 1/3rd of the price of 18 tandem jumps! It is slightly more expensive than the Category System, but you will get much more airtime with instructors, making it the best-value course out there!</p>
         </section>
 
         <hr class="divider" />
 
-        <section class="content-section">
+        <section class="section container">
             <h2>Category System</h2>
             <p>Popular with students on a budget who just want to try it out. The teaching style is different — rather than having in-air coaching, instructors will watch your exit from the plane and provide feedback once you’re on the ground again. Due to the nature of the course, it’s more difficult to complete and can sometimes end up being more costly than AFF if you get stuck on a level, as instructors cannot physically help you fix your body position mid-air. While it’s cheaper on average, it can take 25–30 jumps to finish the course.</p>
         </section>
 
         <p><em>Note that while skydiving courses can be an initial hit on the bank balance, once you’ve got your A Licence, jumps go down to just £20 each when you buy them through us!</em></p>
 
-        <section class="tile-grid" style="grid-template-columns: repeat(2, minmax(0,1fr));">
+        <section class="tile-grid section container" style="grid-template-columns: repeat(2, minmax(0,1fr));">
             <a href="category-system.html">
                 <img src="Images/Exit Background.webp" alt="jumper at the plane door">
                 <span>CATEGORY SYSTEM</span>

--- a/history-and-legacy.html
+++ b/history-and-legacy.html
@@ -48,14 +48,14 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero legacy-hero">
             <h1 class="tagline big-tag">HISTORY &amp; LEGACY</h1>
         </section>
 
         <hr class="divider" />
 
-        <section class="presidents-gallery">
+        <section class="presidents-gallery section container">
             <div class="president-backdrop">
                 <div class="president-grid">
                     <div class="president-card">
@@ -98,13 +98,13 @@
 
         <hr class="divider" />
 
-        <section class="alumni-cta">
+        <section class="alumni-cta section container">
             <p>We are always uncovering more to our rich alumni network — if you know of anyone who is not currently on this list, <a href="contact-us.html">pop us an email</a> to get in touch! We would love to see what your experience was!</p>
         </section>
 
         <hr class="divider" />
 
-        <section class="achievements">
+        <section class="achievements section container">
             <h2>ACHIEVEMENTS</h2>
             <div class="achievements-grid">
                 <a href="#" class="achieve-box">COMPETITION<br>RESULTS</a>

--- a/how-to-join.html
+++ b/how-to-join.html
@@ -48,14 +48,14 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero">
             <h1 class="tagline big-tag">HOW TO JOIN</h1>
         </section>
 
         <hr class="divider" />
 
-        <section class="join-section">
+        <section class="join-section section container">
             <div class="join-text">
                 <p>So, how to join us and start skydiving?</p>
                 <p>To learn to skydive solo, you must complete either an <strong>AFF</strong> or a <strong>Static Line</strong> course (see buttons below for details). Both courses start with a day in the classroom, called a groundschool, where you’ll learn all the basics for your first solo jump. After that, it’s up to you—come back to continue jumping until you get your skydiving licence!</p>
@@ -75,7 +75,7 @@
 
         <hr class="divider" />
 
-        <section class="cta-section">
+        <section class="cta-section section container">
             <div class="cta-buttons">
                 <a href="https://su.nottingham.ac.uk/activities/view/skydive" target="_blank" rel="noopener noreferrer" class="btn-su">UoNSU</a>
                 <a href="AFF.html" class="btn-su">AFF COURSE INFO</a>

--- a/info.html
+++ b/info.html
@@ -43,11 +43,11 @@
   </header>
 
   <!-- ============== MAIN ============== -->
-  <main class="info-main">
+  <main class="content">
     <h1 class="page-title">ABOUT US</h1>
     <hr class="divider" />
 
-    <section class="about-section">
+    <section class="about-section section container">
       <p class="about-text">Welcome to the University of Nottingham Skydiving Club! We are a supportive and inclusive club that offers students at the University of Nottingham the chance to gain their <b>skydiving licence</b> and jump out of a plane <b>completely solo!</b></p>
 
       <div class="about-row">
@@ -65,7 +65,7 @@
 
     <hr class="divider" />
 
-    <section class="tile-grid">
+    <section class="tile-grid section container">
       <a href="how-to-join.html">
         <img src="Images/How To Join Thumbnail.webp" alt="How to join">
         <span>HOW TO JOIN</span>

--- a/members-dashboard.html
+++ b/members-dashboard.html
@@ -48,7 +48,7 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero">
             <h2 class="tagline small-tag">Members' Area</h2>
             <h1 class="tagline big-tag">Members' Dashboard</h1>
@@ -56,7 +56,7 @@
 
         <hr class="divider" />
 
-        <section class="content-section">
+        <section class="section container">
             <h2>Getting to Langar and back</h2>
             <p>Use the transport group to find a lift to Langar and back (£2.50 each way). Post when you want to go and someone will hopefully offer to drive you! If not, you can get the train from Nottingham to Bingham and see if someone can pick you up from there.</p>
             <p>Pay for your lifts on the UoNSU shop. If you are a driver, you can log your lifts in the drivers’ page to receive reimbursement through bank transfer or jump tickets. You can view your balance below.</p>
@@ -70,7 +70,7 @@
 
         <hr class="divider" />
 
-        <section class="content-section">
+        <section class="section container">
             <h2>UoN rig hire</h2>
             <p>Before using UoN rigs, please ensure you have read the Kit Brief and signed the Kit Declaration (this should be emailed to skydive@uonsu.com). The rental period runs from September–March and March–September. Kit hire is £70 for 6 months and can be bought from the UoNSU shop.</p>
             <p>Join the UoN Skydiving Kit Users page on Facebook to reserve the rig you’d like to jump. Make sure you fill out the Packing Log after every jump – failure to do so is a kit strike. You can view the responses to the Packing Log below.</p>
@@ -85,7 +85,7 @@
 
         <hr class="divider" />
 
-        <section class="content-section">
+        <section class="section container">
             <h2>Socials</h2>
             <p>We run socials at least every other week and everyone is invited, no membership required! To join the group chat, DM @uonskydiving (Instagram or Facebook) your Facebook username so we can add you to it.</p>
             <div class="btn-grid">
@@ -95,7 +95,7 @@
 
         <hr class="divider" />
 
-        <section class="content-section">
+        <section class="section container">
             <h2>Welfare</h2>
             <p>The committee cares about your wellbeing and we want you to feel comfortable and included within the club. If you’re experiencing any problems, or you’d just like to chat to someone, we’ve got your back.</p>
             <p>You can use the form below to let us know how you’re doing/ask for support, or report an incident. It is anonymous unless you leave your name, so if you’ve seen something that made you uncomfortable, please tell us about it so we can help make sure the club remains a safe space for everyone!</p>

--- a/our-committee.html
+++ b/our-committee.html
@@ -48,12 +48,12 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero committee-hero">
             <h1 class="tagline big-tag">Our COMMITTEE</h1>
         </section>
 
-        <section class="committee-section">
+        <section class="committee-section section container">
             <div class="committee-grid">
                 <figure class="committee-card" tabindex="0">
                     <img src="Images/committee/placeholder.svg" alt="Photo of President">

--- a/past-committee.html
+++ b/past-committee.html
@@ -48,14 +48,14 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero past-committee-hero">
             <h1 class="tagline big-tag">OUR COMMITTEE</h1>
         </section>
 
         <hr class="divider" />
 
-        <section class="committee-section">
+        <section class="committee-section section container">
             <div class="committee-grid">
                 <figure class="committee-card" tabindex="0">
                     <img src="Images/committee/placeholder.svg" alt="Headshot of Jasper Pyer" onerror="this.onerror=null;this.src='Images/committee/placeholder.svg';">
@@ -125,7 +125,7 @@
 
         <hr class="divider" />
 
-        <section class="qualifiers-section">
+        <section class="qualifiers-section section container">
             <h2>QUALIFIERS</h2>
             <h3>2023/24</h3>
             <ul class="qualifiers-list">

--- a/prices.html
+++ b/prices.html
@@ -48,7 +48,7 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero">
             <h2 class="tagline small-tag">Course Costs</h2>
             <h1 class="tagline big-tag page-title">Prices</h1>
@@ -57,7 +57,7 @@
         <hr class="divider" />
 
         <!-- ================= CATEGORY SYSTEM PRICES ================= -->
-        <section class="pricing-section">
+        <section class="pricing-section section container">
             <h2>PRICES</h2>
             <div class="pricing-grid">
                 <div class="price-item">
@@ -81,7 +81,7 @@
         <hr class="divider" />
 
         <!-- ================= AFF PRICES ================= -->
-        <section class="pricing-section">
+        <section class="pricing-section section container">
             <h2>AFF (ACCELERATED FREEFALL)</h2>
             <div class="pricing-grid">
                 <div class="price-item">

--- a/style.css
+++ b/style.css
@@ -57,6 +57,25 @@ body:not(.home-page)::after {
     z-index: -1;
 }
 
+/* LAYOUT UTILITIES ----------------------------------------------- */
+.container {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+.section {
+    padding: 2rem 0;
+}
+
+.content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+    padding: 2rem 0 3rem;
+}
+
 /* HEADER ------------------------------------------------------------ */
 .site-header {
     position: relative;
@@ -173,15 +192,8 @@ body:not(.home-page)::after {
     .big-tag   { font-size: clamp(2.5rem, 5vw, 5rem); }
 }
 
-/* INFO PAGE LAYOUT ------------------------------------------------ */
-.info-main {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 3rem;
-    padding: 2rem 1.5rem 3rem;
-}
-.info-main .page-title {
+/* PAGE CONTENT ---------------------------------------------------- */
+.content .page-title {
     font-family: 'Futura', sans-serif;
     font-size: clamp(2rem, 5vw, 2.5rem);
 }
@@ -335,7 +347,6 @@ body:not(.home-page)::after {
 
 /* PRICING PAGE STYLES -------------------------------------------- */
 .pricing-section {
-    padding: 5rem 1.5rem 2rem;
 }
 
 .pricing-section h2 {
@@ -390,7 +401,6 @@ body:not(.home-page)::after {
 /* FAQ PAGE STYLES ------------------------------------------------- */
 
 .faq-section {
-    padding: 5rem 1.5rem 2rem;
 }
 
 .faq-section .page-title {
@@ -452,12 +462,6 @@ body:not(.home-page)::after {
     z-index: -1;
 }
 
-.licence-section {
-    padding: 5rem 1.5rem 2rem;
-    max-width: 1000px;
-    margin: 0 auto;
-}
-
 .section-title {
     font-size: clamp(2rem, 5vw, 2.5rem);
     text-transform: uppercase;
@@ -508,7 +512,7 @@ body.contact-page::after {
     background: rgba(0,0,0,0.5);
 }
 
-.contact-hero {
+.hero.centered {
     justify-content: center;
 }
 
@@ -530,9 +534,6 @@ body.contact-page::after {
 
 /* CATEGORY SYSTEM PAGE STYLES ------------------------------------ */
 .intro-summary {
-    padding: 5rem 1.5rem 2rem;
-    max-width: 1000px;
-    margin: 0 auto;
 }
 
 .intro-list {
@@ -548,15 +549,9 @@ body.contact-page::after {
 }
 
 .course-overview {
-    padding: 5rem 1.5rem 2rem;
-    max-width: 1000px;
-    margin: 0 auto;
 }
 
 .course-section {
-    padding: 5rem 1.5rem 2rem;
-    max-width: 1000px;
-    margin: 0 auto;
 }
 
 .course-container {
@@ -755,15 +750,12 @@ body.committee-page::before {
 }
 
 .committee-section {
-    padding: 4rem 1.5rem 3rem;
     background-color: #000;
 }
 
 .committee-grid {
     display: grid;
     gap: 2rem;
-    max-width: 1200px;
-    margin: 0 auto;
     grid-template-columns: 1fr;
 }
 
@@ -801,10 +793,7 @@ body.committee-page::before {
 }
 
 .qualifiers-section {
-    padding: 4rem 1.5rem;
     background-color: #000;
-    max-width: 800px;
-    margin: 0 auto;
 }
 
 .qualifiers-list {
@@ -885,9 +874,6 @@ body.committee-page::before {
     display: grid;
     grid-template-columns: repeat(3, minmax(0,1fr));
     gap: 2rem;
-    max-width: 1000px;
-    margin: 0 auto;
-    padding: 4rem 1.5rem;
 }
 
 .president-card {
@@ -931,15 +917,12 @@ body.committee-page::before {
 }
 
 .president-legacy {
-    max-width: 1000px;
     margin: 4rem auto;
-    padding: 0 1.5rem;
 }
 .president-legacy .outline-btn { margin-top: 0.5rem; }
 
 .alumni-cta {
     background: #111;
-    padding: 3rem 1.5rem;
     font-size: 1.25rem;
     font-weight: 700;
     line-height: 1.6;
@@ -948,7 +931,6 @@ body.committee-page::before {
 .alumni-cta a { color: #fff; text-decoration: underline; }
 
 .achievements {
-    padding: 3rem 1.5rem;
 }
 .achievements h2 {
     text-align: center;
@@ -963,8 +945,6 @@ body.committee-page::before {
     display: grid;
     grid-template-columns: repeat(4, minmax(0,1fr));
     gap: 1.5rem;
-    max-width: 1000px;
-    margin: 0 auto;
 }
 .achieve-box {
     display: flex;
@@ -997,9 +977,6 @@ body.committee-page::before {
 
 /* HOW TO JOIN PAGE STYLES -------------------------------------- */
 .join-section {
-    max-width: 1000px;
-    margin: 0 auto;
-    padding: 2rem 1.5rem;
     display: flex;
     flex-wrap: wrap;
     gap: 2rem;

--- a/template.html
+++ b/template.html
@@ -48,7 +48,7 @@
     </header>
 
     <!-- ================= MAIN CONTENT ================= -->
-    <main>
+    <main class="content">
         <section class="hero">
             <h2 class="tagline small-tag">Subtitle goes here</h2>
             <h1 class="tagline big-tag">Page Title</h1>
@@ -56,14 +56,14 @@
 
         <hr class="divider" />
 
-        <section class="content-section">
+        <section class="section container">
             <h2>Section Title</h2>
             <p>Content goes here...</p>
         </section>
 
         <hr class="divider" />
 
-        <section class="content-section">
+        <section class="section container">
             <h2>Another Section</h2>
             <p>More content...</p>
         </section>


### PR DESCRIPTION
## Summary
- add reusable `.container`, `.section`, and `.content` utilities
- replace page-specific hero centering with `.hero.centered`
- update site pages to use shared layout classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1d97e798832cbfa7d9534bbbffed