### PR TITLE
Improve licence page hero and layout

### DIFF
--- a/getting-your-licence.html
+++ b/getting-your-licence.html
@@ -50,34 +50,31 @@
     <!-- ================= MAIN CONTENT ================= -->
     <main>
         <section class="hero">
-            <h1 class="tagline big-tag">GETTING YOUR LICENCE</h1>
-            <p>When you join UoN Skydiving, you’ll have the exciting opportunity to pursue your skydiving licence through two different courses: Accelerated Freefall (AFF) or the Category System.
-Both courses lead to earning your A Licence, but have different prices and teaching styles. Check out our course pages below to decide which one you want to do, and then drop us an email at skydive@uonsu.com to book your spot!</p>
+            <div class="hero-inner">
+                <div class="hero-text">
+                    <h1 class="tagline big-tag">GETTING YOUR LICENCE</h1>
+                    <p>When you join UoN Skydiving, you’ll have the exciting opportunity to pursue your skydiving licence through two different courses: Accelerated Freefall (AFF) or the Category System.</p>
+                    <p>Both courses lead to earning your A Licence, but have different prices and teaching styles. Check out our course pages below to decide which one you want to do, and then drop us an email at skydive@uonsu.com to book your spot!</p>
+                </div>
+                <div class="hero-media">
+                    <img src="Images/A-Licence.webp" alt="Skydiver celebrating their A Licence">
+                </div>
+            </div>
         </section>
-
-        <hr class="divider" />
-
-        <section class="content-section">
-            <h2>Accelerated Freefall (AFF)</h2>
+        <section class="course-intro">
             <p>AFF is the most common and popular option of learning to skydive worldwide. You will progress faster and enjoy freefall from your first jump, with the help of instructors jumping with you to coach you and give feedback. You have the option to pay as you go, or to pay upfront after your first jump for a discount. You will have a skydiving licence in 18 solo jumps, at 1/3rd of the price of 18 tandem jumps! It is slightly more expensive than the Category System, but you will get much more airtime with instructors, making it the best-value course out there!</p>
+            <p>Alternatively, the Category System is popular with students on a budget who just want to try it out. The teaching style is different, rather than having in-air coaching, instructors will watch your exit from the plane and provide feedback once you’re on the ground again. Due to the nature of the course, it’s more difficult to complete and can sometimes end up being more costly than AFF if you get stuck on a level, as instructors cannot physically help you fix your body position, while they can in AFF. So while it’s cheaper on average, it can take 25-30 jumps to finish the course.</p>
+            <p><em>Note that while skydiving courses can be an initial hit on the bank balance, once you’ve got your A Licence, jumps go down to just £20 each when you buy them through us!</em></p>
+            <p>Check out the course pages below to help you decide which one’s right for you!</p>
         </section>
 
-        <hr class="divider" />
-
-        <section class="content-section">
-            <h2>Category System</h2>
-            <p>Popular with students on a budget who just want to try it out. The teaching style is different — rather than having in-air coaching, instructors will watch your exit from the plane and provide feedback once you’re on the ground again. Due to the nature of the course, it’s more difficult to complete and can sometimes end up being more costly than AFF if you get stuck on a level, as instructors cannot physically help you fix your body position mid-air. While it’s cheaper on average, it can take 25–30 jumps to finish the course.</p>
-        </section>
-
-        <p><em>Note that while skydiving courses can be an initial hit on the bank balance, once you’ve got your A Licence, jumps go down to just £20 each when you buy them through us!</em></p>
-
-        <section class="tile-grid" style="grid-template-columns: repeat(2, minmax(0,1fr));">
+        <section class="tile-grid">
             <a href="category-system.html">
-                <img src="Images/Exit Background.webp" alt="jumper at the plane door">
-                <span>CATEGORY SYSTEM</span>
+                <img src="Images/Dom Category System.webp" alt="Dom exiting aircraft during Category System jump">
+                <span>Category System</span>
             </a>
             <a href="AFF.html">
-                <img src="Images/Funnel Background.webp" alt="skydivers in freefall holding formation">
+                <img src="Images/AFF Top Down.webp" alt="top-down view of an AFF jump">
                 <span>AFF</span>
             </a>
         </section>

--- a/style.css
+++ b/style.css
@@ -46,6 +46,10 @@ body.faqs-page::before {
     background-repeat: no-repeat;
 }
 
+body.licence-page::before {
+    background: url('Images/Canopy Through Trees Background.webp') top center/cover no-repeat;
+}
+
 body:not(.home-page)::after {
     content: '';
     position: absolute;
@@ -213,26 +217,27 @@ body:not(.home-page)::after {
 
 /* TILE GRID ------------------------------------------------------- */
 .tile-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 2rem; text-align: center; }
-/* BUTTON GRID ---------------------------------------------------- */
-.btn-grid { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; margin-top: 1rem; }
-.btn-grid a { flex: 1 1 200px; text-align: center; }
 
 @media (max-width: 700px) {
     .tile-grid { display: flex; flex-direction: column; gap: 2rem; align-items: center; }
     .tile-grid > a { width: 100%; max-width: 340px; }
 }
-.tile-grid img { width: 100%; aspect-ratio: 4 / 3; object-fit: cover; display: block; }
+.tile-grid img { width: 100%; aspect-ratio: 3 / 4; object-fit: cover; object-position: center; display: block; }
 .tile-grid a {
+    position: relative;
     text-decoration: none;
     color: #fff;
     font-family: 'Soho Std Light','Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     font-weight: 800;
     font-size: 1.25rem;
-    text-transform: uppercase;
     letter-spacing: .03em;
 }
-.tile-grid a span { display: inline-block; margin-top: .75rem; border-bottom: 2px solid #fff; }
-.tile-grid a:hover span { color: var(--brand-gold); border-bottom-color: var(--brand-gold); }
+.tile-grid a span {
+    position: absolute;
+    left: 1rem;
+    bottom: 20%;
+}
+.tile-grid a:hover span { color: var(--brand-gold); }
 
 /* BUTTON GRID ---------------------------------------------------- */
 .btn-grid { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; margin-top: 1rem; }
@@ -439,64 +444,20 @@ body:not(.home-page)::after {
 }
 
 /* LICENCE PAGE STYLES -------------------------------------------- */
-.licence-hero {
-    position: relative;
-    overflow: hidden;
-}
-.licence-hero::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: url('Images/Home Page Background.png') center/cover no-repeat;
-    filter: blur(4px) brightness(0.6);
-    z-index: -1;
+.licence-page .tagline {
+    font-family: 'Futura PT', 'Futura', sans-serif;
 }
 
-.licence-section {
-    padding: 5rem 1.5rem 2rem;
-    max-width: 1000px;
-    margin: 0 auto;
+.licence-page .hero-text {
+    text-align: left;
 }
 
-.section-title {
-    font-size: clamp(2rem, 5vw, 2.5rem);
-    text-transform: uppercase;
-    font-weight: 800;
-    text-align: center;
-    margin-bottom: 2rem;
+.licence-page .big-tag {
+    white-space: normal;
 }
 
-.licence-content {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 2rem;
-    align-items: center;
-    margin-bottom: 2rem;
-}
-
-.text-content {
-    flex: 1 1 300px;
-}
-
-.image-content {
-    flex: 0 1 350px;
-}
-.image-content img {
-    width: 100%;
-    height: auto;
-    display: block;
-}
-
-.course-comparison p {
-    margin-bottom: 1.5rem;
-}
-
-.course-comparison .note {
-    font-style: italic;
-}
-
-.course-comparison strong {
-    font-weight: 800;
+.licence-page .tile-grid {
+    grid-template-columns: repeat(2, minmax(0,1fr));
 }
 
 body.contact-page::before {
@@ -625,6 +586,12 @@ body.contact-page::after {
     height: auto;
     display: block;
     box-shadow: 0 4px 8px rgba(0,0,0,0.5);
+}
+
+.course-intro p {
+    font-family: 'Soho Std', 'Soho', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    font-weight: 400;
+    margin-bottom: 1rem;
 }
 
 .hero-list {


### PR DESCRIPTION
## Summary
- Wrap licence hero title and align course tile grid via stylesheet instead of inline styles
- Specify Soho Std regular for course intro paragraphs and enable heading wrapping on narrow screens
- Remove temporary A Licence image placeholder while keeping hero markup referencing it for later asset add

## Testing
- `npx htmlhint getting-your-licence.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68a709d2c940832c8dae582a58b59527